### PR TITLE
Update Spring Cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-build</artifactId>
-        <version>1.1.0.RC1</version>
+        <version>1.1.0.RELEASE</version>
         <relativePath></relativePath>
         <!-- lookup parent from repository -->
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-build</artifactId>
-        <version>1.1.0.RELEASE</version>
-        <relativePath></relativePath>
-        <!-- lookup parent from repository -->
-    </parent>
+
     <groupId>net.smartcosmos</groupId>
     <artifactId>smartcosmos-build</artifactId>
     <version>3.0.0-SNAPSHOT</version>
@@ -54,6 +48,7 @@
         <release.serverId>deployment</release.serverId>
         <resource.delimiter>@</resource.delimiter>
         <sortpom-maven-plugin.version>2.5.0</sortpom-maven-plugin.version>
+        <spring-boot.version>1.3.3.RELEASE</spring-boot.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <release.serverId>deployment</release.serverId>
         <resource.delimiter>@</resource.delimiter>
         <sortpom-maven-plugin.version>2.5.0</sortpom-maven-plugin.version>
-        <spring-boot.version>1.3.3.RELEASE</spring-boot.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/smartcosmos-build-dependencies/pom.xml
+++ b/smartcosmos-build-dependencies/pom.xml
@@ -19,12 +19,6 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-dependencies-parent</artifactId>
-        <version>1.1.0.RC1</version>
-        <relativePath></relativePath>
-    </parent>
     <groupId>net.smartcosmos</groupId>
     <artifactId>smartcosmos-build-dependencies</artifactId>
     <version>3.0.0-SNAPSHOT</version>
@@ -50,6 +44,7 @@
         <!-- Override this for public releases. -->
         <release.serverId>deployment</release.serverId>
         <sortpom-maven-plugin.version>2.5.0</sortpom-maven-plugin.version>
+        <spring-boot.version>1.3.4.RELEASE</spring-boot.version>
         <spring-cloud.version>Brixton.RELEASE</spring-cloud.version>
         <spring-mock-mvc.version>2.8.0</spring-mock-mvc.version>
         <springfox.version>2.4.0</springfox.version>
@@ -86,6 +81,13 @@
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-annotations</artifactId>
                 <version>${swagger-annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>

--- a/smartcosmos-build-dependencies/pom.xml
+++ b/smartcosmos-build-dependencies/pom.xml
@@ -34,6 +34,7 @@
         <javax.inject.version>1</javax.inject.version>
         <javax.jsr.version>1.1.1</javax.jsr.version>
         <javax.validation.version>1.1.0.Final</javax.validation.version>
+        <lombok.version>1.16.6</lombok.version>
         <maven-enforcer-plugin.version>1.3.1</maven-enforcer-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
@@ -56,6 +57,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
                 <version>${commons-collections4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.querydsl</groupId>


### PR DESCRIPTION
This removes Spring Cloud from the parent structure to avoid any potential issues in the future, also updates Spring Boot and adds in Spring Boot's dependency structure directly rather than implicitly through Spring Cloud.  Should not cause any issues, but better to do this now than after release and encounter potential issues.
