### PR TITLE
Replace project.version by hard-coded version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>net.smartcosmos</groupId>
                 <artifactId>smartcosmos-build-dependencies</artifactId>
-                <version>${project.version}</version>
+                <version>3.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
The dependency version for `net.smartcosmos:smartcosmos-build-dependencies` in `smartcosmos-build` is changed from the Maven variable `${project.version}` to a hard-coded version string `3.0.0-SNAPSHOT`.

This might be a temporary fix for the issue described in [OBJECTS-955](https://smartractechnology.atlassian.net/browse/OBJECTS-955), but I rather use a fixed version for now that create another artifact that starts with version 3.0.0-SNAPSHOT.
