### PR TITLE
Adds a public profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -559,5 +559,21 @@
                 <downloadUrl>https://github.com/SMARTRACTECHNOLOGY</downloadUrl>
             </distributionManagement>
         </profile>
+        <profile>
+            <id>public</id>
+            <distributionManagement>
+                <repository>
+                    <id>ossrh</id>
+                    <name>Sonatype OSS Snapshots</name>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <name>Maven Central</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                </snapshotRepository>
+                <downloadUrl>https://github.com/SMARTRACTECHNOLOGY</downloadUrl>
+            </distributionManagement>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This enables builds with the `-Ppublic` to deploy to Sonatype OSS for snapshots and Maven Central for releases.
