### PR TITLE
Removes `distributionManagement` from pom file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,19 +419,6 @@
         <url>https://github.com/SMARTRACTECHNOLOGY/smartcosmos-cluster/tree/master/</url>
         <tag>HEAD</tag>
     </scm>
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <name>SMART COSMOS Objects Releases</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <name>SMART COSMOS Objects Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
-        <downloadUrl>https://github.com/SMARTRACTECHNOLOGY</downloadUrl>
-    </distributionManagement>
     <profiles>
         <profile>
             <id>spring</id>


### PR DESCRIPTION
Removes `distributionManagement` from pom file, causing failures once the pom hierarchy is cleaned up.

_DO NOT MERGE UNTIL Jenkins is properly configured_

This should ideally be done after: https://github.com/SMARTRACTECHNOLOGY/smartcosmos-build/pull/13
